### PR TITLE
Fix next config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,9 +2,6 @@
 const nextConfig = {
   // Enable strict mode and keep App Router disabled for compatibility with pages directory
   reactStrictMode: true,
-  experimental: {
-    appDir: false,
-  },
   // Allow importing SVGs as React components
   webpack(config) {
     config.module.rules.push({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
       "@/components/*": ["apps/dashboard/components/*"],
       "@/lib/*": ["apps/dashboard/lib/*"],
       "@/ui/*": ["libs/ui/*"],
-      "@/ml/*": ["libs/ml/*"]
+      "@/ml/*": ["libs/ml/*"],
+      "@/styles/*": ["apps/dashboard/styles/*"]
     }
   },
   "include": [


### PR DESCRIPTION
## Summary
- remove deprecated `experimental.appDir` from next config
- add path alias for styles

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run typecheck` *(fails: numerous TS errors)*
- `npm test` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_e_6884d7cccb10832092e6423fd836aeb0