### PR TITLE
Fix dashboard tsconfig inheritance

### DIFF
--- a/apps/dashboard/tsconfig.json
+++ b/apps/dashboard/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
     "lib": [
       "dom",


### PR DESCRIPTION
## Summary
- inherit root tsconfig settings in dashboard

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884decb17948320a6bf69671bb2f883