### PR TITLE
Fix date rendering locale mismatch

### DIFF
--- a/apps/dashboard/pages/index.tsx
+++ b/apps/dashboard/pages/index.tsx
@@ -36,7 +36,7 @@ const HomePage: React.FC = () => {
         </div>
         <div className="p-4 border rounded shadow-sm">
           <h2 className="text-xl font-semibold">Posledná aktualizácia</h2>
-          <p className="text-2xl mt-2 font-bold">{new Date().toLocaleDateString()}</p>
+          <p className="text-2xl mt-2 font-bold">{new Date().toLocaleDateString('sk-SK')}</p>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- set explicit locale for date rendering to fix hydration errors

## Testing
- `npm test` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68851c33167883209b44a77f106daddb